### PR TITLE
Show right command

### DIFF
--- a/lua/autorun/sh_hangman_core.lua
+++ b/lua/autorun/sh_hangman_core.lua
@@ -14,7 +14,7 @@ if SERVER then
 			ply:PS_GivePoints(5)
 		end
 		for k, v in pairs(player.GetAll()) do
-			v:ChatPrint(""..ply:Nick().." just won "..NiandraMinigames.HangmanWinPoints.." points from Hangman! Type /hangman to do the same.")
+			v:ChatPrint(""..ply:Nick().." just won "..NiandraMinigames.HangmanWinPoints.." points from Hangman! Type "..NiandraMinigames.ChatCommand.." to do the same.")
 		end
 	end)
 	


### PR DESCRIPTION
When someone win hangman, the wrong text is displayed in public if the command is changed from default.
